### PR TITLE
Reduce font size by half

### DIFF
--- a/landing-styles.css
+++ b/landing-styles.css
@@ -612,7 +612,7 @@ body {
 }
 
 .form-disclaimer {
-  font-size: 0.9rem;
+  font-size: 0.45rem;
   opacity: 0.8;
   margin-top: 15px;
   line-height: 1.4;


### PR DESCRIPTION
Decrease the font size of the form disclaimer text by half to meet user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-c800fdb1-22eb-4200-8270-0a73811f7979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c800fdb1-22eb-4200-8270-0a73811f7979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>